### PR TITLE
Conditional survey question

### DIFF
--- a/static/measure/setup.js
+++ b/static/measure/setup.js
@@ -2,6 +2,7 @@ import { initSurvey } from '/static/measure/survey.js'
 import runTests from '/static/test/runTests.js'
 import handleResults from "/static/measure/handleResults.js"
 import config from '/static/measure/config.js'
+import { LOCAL_TESTING_FLAG } from '/static/utils/constants.js'
 
 // Document selectors
 const addressRequired = document.getElementById('address').getAttribute('address-required')
@@ -194,7 +195,7 @@ function onPlaceChanged() {
  * Validates the address entered. Either displays a warning or begins the test
  */
 function validateAddress() {
-  if ((document.getElementById('autocomplete').value === '' || !address.lat || !address.lon) && addressRequired) {
+  if (!LOCAL_TESTING_FLAG && (document.getElementById('autocomplete').value === '' || !address.lat || !address.lon) && addressRequired) {
     addressWarningElement.style.display = 'block'
   } else {
     beginTest()
@@ -271,7 +272,7 @@ async function beginTest() {
   metadata = await metadata
 
   // Sets up the survey
-  initSurvey(metadata.ip)
+ initSurvey(metadata.ip)
 
   // Set up test display
   ispNameElement.textContent = metadata.isp

--- a/static/measure/survey.js
+++ b/static/measure/survey.js
@@ -309,18 +309,15 @@ async function nextQuestion() {
                         // Update existing isHome array in local storage
                         localStorage.setItem('isHome', JSON.stringify(isHomeArray))
                     }
-                    console.log('here2')
                     for (let i = 0; i < questions.length; i++) {
                         if (questions[i].id == 5) {
                             questions.splice(i, 1)
-                            console.log(i)
                             addToAnsweredQs([5], ipAddressConstant)
                         }
                     }
                     for (let i = 0; i < questions.length; i++) {
                         if (questions[i].id == 6) {
                             questions.splice(i, 1)
-                            console.log(i)
                             addToAnsweredQs([6], ipAddressConstant)
                         }
                     }

--- a/static/measure/survey.js
+++ b/static/measure/survey.js
@@ -20,10 +20,11 @@ let numQuestions
 let response = {}
 let answeredQuestions = []
 let progressIncrement
+let ipAddressConstant
 
 /**
  * Fetches an array of survey questions to display to the user
- * @param {*} questionIDArray an array of question IDs to exclude from the database
+ * @param {*} excludeQuestions an array of question IDs to exclude from the database
  * @returns an array of question to display
  */
 function getSurveyQuestions(excludeQuestions) {
@@ -36,6 +37,8 @@ function getSurveyQuestions(excludeQuestions) {
 
         if (questionSet.length >= 9) break
     }
+
+    
     
     return questionSet
 }
@@ -46,6 +49,7 @@ function getSurveyQuestions(excludeQuestions) {
  * @param {*} ipAddress as a string 
  */
 async function initSurvey(ipAddress) {
+    ipAddressConstant = ipAddress
     // Get an array of already answered qurstions from local storage
     let excludeQuestionsArray = JSON.parse(localStorage.getItem('answeredQs'))
     let excludeQuestions = []
@@ -57,8 +61,27 @@ async function initSurvey(ipAddress) {
         }
     }
 
-    // Fetch the survey questions from the database
+    // Fetch the survey questions 
     questions = getSurveyQuestions(excludeQuestions)
+    /*
+    console.log(questions)
+    let isHomeArray = JSON.parse(localStorage.getItem('isHome'))
+    if(isHomeArray) {
+        for (let i = 0; i < isHomeArray.length; i++ ) {
+            if (isHomeArray[i].ipAddress === ipAddress && isHomeArray[i].answered === false ) {
+                for (let i = 0; i < questions.length; i++) {
+                    if (questions[i].id === 5) {
+                        questions.splice(i, 1)
+                    }
+                    if (questions[i].id === 6) {
+                        questions.splice(i, 1)
+                    }
+                }
+                
+            }
+        }
+    }
+    console.log(questions) */
 
     // Set variables for survey progress bar
     numQuestions = questions.length
@@ -257,6 +280,56 @@ async function nextQuestion() {
         for (let radioButton of radioButtons) {
             if (radioButton.checked) {
                 answeredFlag = true
+
+                if (radioButton.value === 'School' || radioButton.value === 'Business') {
+
+                    let isHomeArray = JSON.parse(localStorage.getItem('isHome'))
+                    let isHomeExistsFlag
+
+                    // If isHome array doesn't exist in Local Storage (first time taking the survey), create new ip address object
+                    if (isHomeArray === null) {
+                        localStorage.setItem('isHome', JSON.stringify([{ipAddress: ipAddressConstant, answered: false}]))
+                    } 
+                    // Otherwise loop thru isHome array and update the proper object depending on ip address
+                    else {
+                        for (let i = 0; i < isHomeArray.length; i++) {
+                            if (isHomeArray[i].ipAddress === ipAddressConstant) {
+                                isHomeArray[i].answered = false
+                                isHomeExistsFlag = true
+                            }
+                        }
+                        // If ip address doesn't yet exist in the isHome array, create new obj for it
+                        if (!isHomeExistsFlag) {
+                            isHomeArray.push({ipAddress: ipAddressConstant, answered: false})
+                        }
+                        // Update existing isHome array in local storage
+                        localStorage.setItem('isHome', JSON.stringify(isHomeArray))
+                    }
+                    console.log('here')
+                } else if (radioButton.value === 'Home') {
+                    let isHomeArray = JSON.parse(localStorage.getItem('isHome'))
+                    let isHomeExistsFlag
+
+                    // If isHome array doesn't exist in Local Storage (first time taking the survey), create new ip address object
+                    if (isHomeArray === null) {
+                        localStorage.setItem('isHome', JSON.stringify([{ipAddress: ipAddressConstant, answered: true}]))
+                    } 
+                    // Otherwise loop thru isHome array and update the proper object depending on ip address
+                    else {
+                        for (let i = 0; i < isHomeArray.length; i++) {
+                            if (isHomeArray[i].ipAddress === ipAddressConstant) {
+                                isHomeArray[i].answered = true
+                                isHomeExistsFlag = true
+                            }
+                        }
+                        // If ip address doesn't yet exist in the isHome array, create new obj for it
+                        if (!isHomeExistsFlag) {
+                            isHomeArray.push({ipAddress: ipAddressConstant, answered: true})
+                        }
+                        // Update existing isHome array in local storage
+                        localStorage.setItem('isHome', JSON.stringify(isHomeArray))
+                    }
+                }
 
                 response[question.attribute] = {
                     value: radioButton.value,

--- a/static/measure/survey.js
+++ b/static/measure/survey.js
@@ -63,25 +63,29 @@ async function initSurvey(ipAddress) {
 
     // Fetch the survey questions 
     questions = getSurveyQuestions(excludeQuestions)
-    /*
+    
     console.log(questions)
     let isHomeArray = JSON.parse(localStorage.getItem('isHome'))
     if(isHomeArray) {
         for (let i = 0; i < isHomeArray.length; i++ ) {
             if (isHomeArray[i].ipAddress === ipAddress && isHomeArray[i].answered === false ) {
                 for (let i = 0; i < questions.length; i++) {
-                    if (questions[i].id === 5) {
+                    if (questions[i].id == 5) {
                         questions.splice(i, 1)
+                        addToAnsweredQs([5], ipAddress)
                     }
-                    if (questions[i].id === 6) {
+                }
+                for (let i = 0; i < questions.length; i++) {
+                    if (questions[i].id == 6) {
                         questions.splice(i, 1)
+                        addToAnsweredQs([6], ipAddress)
                     }
                 }
                 
             }
         }
     }
-    console.log(questions) */
+    console.log(questions)
 
     // Set variables for survey progress bar
     numQuestions = questions.length
@@ -305,7 +309,25 @@ async function nextQuestion() {
                         // Update existing isHome array in local storage
                         localStorage.setItem('isHome', JSON.stringify(isHomeArray))
                     }
-                    console.log('here')
+                    console.log('here2')
+                    for (let i = 0; i < questions.length; i++) {
+                        if (questions[i].id == 5) {
+                            questions.splice(i, 1)
+                            console.log(i)
+                            addToAnsweredQs([5], ipAddressConstant)
+                        }
+                    }
+                    for (let i = 0; i < questions.length; i++) {
+                        if (questions[i].id == 6) {
+                            questions.splice(i, 1)
+                            console.log(i)
+                            addToAnsweredQs([6], ipAddressConstant)
+                        }
+                    }
+                    numQuestions = questions.length
+                    progressIncrement = 100 / numQuestions
+                    questionTotalElement.textContent = numQuestions
+
                 } else if (radioButton.value === 'Home') {
                     let isHomeArray = JSON.parse(localStorage.getItem('isHome'))
                     let isHomeExistsFlag

--- a/static/utils/constants.js
+++ b/static/utils/constants.js
@@ -190,7 +190,7 @@ export const survey = [
     },
     {
         id: 8,
-        question: "Does anyone in your household use the internet to complete school assignments or job training course work?",
+        question: "Does anyone at your location use the internet to complete school assignments or job training course work?",
         type: "radio",
         answers: ["Yes", "No"],
         attribute: "usesInternetForSchool",

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,7 +1,6 @@
 require('dotenv').config()
 
-let LOCAL_TESTING_FLAG = process.env.NODE_ENV !== 'production'
-LOCAL_TESTING_FLAG = false
+const LOCAL_TESTING_FLAG = process.env.NODE_ENV !== 'production'
 
 const BGA_URLS = {
     local: 'http://localhost:4000/graphql',

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,6 +1,7 @@
 require('dotenv').config()
 
-const LOCAL_TESTING_FLAG = process.env.NODE_ENV !== 'production'
+let LOCAL_TESTING_FLAG = process.env.NODE_ENV !== 'production'
+LOCAL_TESTING_FLAG = false
 
 const BGA_URLS = {
     local: 'http://localhost:4000/graphql',


### PR DESCRIPTION
## Description <!-- Please be descriptive about what changes are being made and why -->

- Added conditional rendering of "home" related survey questions depending on location type selected in prior survey question

## Tests <!-- Have these changes been tested? Unit tests? -->

- Manual tests

1. Go to the reset route first to clear local storage
2. Take the survey and select "School" or "Business" location type

Expected behavior:
- If selected school or business, home related questions that exist in the current set of survey questions are removed/not displayed, and total num of questions for the current test gets bumped down to 7 instead of 9
- If location type question was answered in a previous speed test, then home related questions do not appear in the 9 questions when the survey is initialized


## Related Issues <!-- Close the issues here if any exist -->
Closes ready/multitest#80
