### PR TITLE
Update results and history to use median fields from database

### DIFF
--- a/static/history/history.js
+++ b/static/history/history.js
@@ -42,10 +42,10 @@ function fillTable(results) {
         const rollup = rollupResults(result)
 
         // Set the text content for the row element
-        rowData[0].textContent = rollup.upload
-        rowData[1].textContent = rollup.download
-        rowData[2].textContent = rollup.latency
-        rowData[3].textContent = rollup.jitter
+        rowData[0].textContent = result.medianUpload
+        rowData[1].textContent = result.medianDownload
+        rowData[2].textContent = result.medianLatency
+        rowData[3].textContent = result.medianJitter
         rowData[4].textContent = new Date(result.createdAt).toLocaleDateString()
 
         // Append the row to the table
@@ -96,6 +96,10 @@ async function getNextPage() {
                     ooklaJitter
                     ooklaUpload
                     ooklaDownload
+                    medianLatency
+                    medianJitter
+                    medianUpload
+                    medianDownload
                     ipAddress
                     ispName
                     createdAt

--- a/templates/historyTemplate.js
+++ b/templates/historyTemplate.js
@@ -39,9 +39,9 @@ function historyTemplate(config) {
               <button class="underline-button" id="load-more-btn" onclick="loadMore()">Load more</button>
             </div>
           </div>
-          <div class="background-container" id="history-empty">
-            <h2>No results yet</h2>
-            <h3>You may view your results after you take the internet strength test</h3>
+          <div class="background-container" id="history-empty" style="align-self: center">
+            <h2 class="main-heading">No results yet</h2>
+            <h3 class="section-description">You may view your results after you take the internet strength test</h3>
           </div>
           ${landscapeBackground}
         </div>

--- a/utils/resultsUtils.js
+++ b/utils/resultsUtils.js
@@ -65,47 +65,6 @@ function getServiceClassName(status) {
 }
 
 /**
- * Gets the median from an array of values
- * @param {*} array 
- * @returns The median value
- */
-function getMedian(array) {
-    let concat = array;
-    concat = concat.sort(
-        function (a, b) { return a - b })
-
-    let length = concat.length
-
-    if (length % 2 == 1) {
-        return concat[(length / 2) - .5]
-    }
-    else {
-        return (concat[length / 2] + concat[(length / 2) - 1]) / 2
-    }
-}
-
-/**
- * Gets the rollup results by getting the median values across
- * all three speed tests
- * @param {*} results An object containing test results
- * @returns An object containing rollup results
- */
-function rollupResults(results) {
-
-    const downloadMedian = getMedian([results.mlabDownload, results.rstDownload, results.ooklaDownload])
-    const uploadMedian = getMedian([results.mlabUpload, results.rstUpload, results.ooklaUpload])
-    const latencyMedian = getMedian([results.mlabLatency, results.rstLatency, results.ooklaLatency])
-    const jitterMedian = getMedian([results.mlabJitter, results.rstJitter, results.ooklaJitter])
-
-    return {
-        download: downloadMedian,
-        upload: uploadMedian,
-        latency: latencyMedian,
-        jitter: jitterMedian
-    }
-}
-
-/**
  * Fetches the results from a result id
  * @param {*} id The id of the results to fetch
  * @returns An object containing the fetched results
@@ -126,6 +85,10 @@ exports.getResults = async (id) => {
                 ooklaJitter
                 ooklaUpload
                 ooklaDownload
+                medianLatency
+                medianJitter
+                medianUpload
+                medianDownload
             }
         }`
     });
@@ -150,13 +113,11 @@ exports.getResults = async (id) => {
  * @returns An object containing information to display on the results page
  */
 exports.getResultsFields = (results) => {
-    const rollup = rollupResults(results)
-
-    const serviceStatusText = getOverallServiceStatus(rollup.download, rollup.upload)
+    const serviceStatusText = getOverallServiceStatus(results.medianDownload, results.medianUpload)
     const serviceStatusClass = getServiceClassName(serviceStatusText)
-    const downloadServiceStatusText = getDownloadServiceStatus(rollup.download)
+    const downloadServiceStatusText = getDownloadServiceStatus(results.medianDownload)
     const downloadServiceStatusClass = getServiceClassName(downloadServiceStatusText)
-    const uploadServiceStatusText = getUploadServiceStatus(rollup.upload)
+    const uploadServiceStatusText = getUploadServiceStatus(results.medianUpload)
     const uploadServiceStatusClass = getServiceClassName(uploadServiceStatusText)
     
     const mlabServiceStatusText = getOverallServiceStatus(results.mlabDownload, results.mlabUpload)
@@ -205,10 +166,10 @@ exports.getResultsFields = (results) => {
         ooklaDownloadServiceStatusClass,
         ooklaUploadServiceStatusText,
         ooklaUploadServiceStatusClass,
-        downloadRollup: rollup.download,
-        uploadRollup: rollup.upload,
-        latencyRollup: rollup.latency,
-        jitterRollup: rollup.jitter,
+        downloadRollup: results.medianDownload,
+        uploadRollup: results.medianUpload,
+        latencyRollup: results.medianLatency,
+        jitterRollup: results.medianJitter,
         mlabDownload: results.mlabDownload,
         mlabUpload: results.mlabUpload,
         mlabLatency: results.mlabLatency,


### PR DESCRIPTION
## Description <!-- Please be descriptive about what changes are being made and why -->

- Displayed test results medians from resolver instead of recalculating in history and results page
- Fixed issue with styling on the empty history display

Closes https://github.com/ready/multitest/issues/102
Closes https://github.com/ready/multitest/issues/104

Must only be deployed after backend is deployed to prod https://github.com/ready/boss-graphql-api/pull/2858