### PR TITLE
chore: add apollo client name for client aware metrics

### DIFF
--- a/static/history/history.js
+++ b/static/history/history.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import { BGA_URL } from '/static/utils/constants.js'
+import { BGA_URL, APOLLO_CLIENT_NAME } from '/static/utils/constants.js'
 import { getUuid } from '/static/utils/cookies.js'
 
 // Document selectors
@@ -117,7 +117,8 @@ async function getNextPage() {
     return fetch(BGA_URL, {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'apollographql-client-name': APOLLO_CLIENT_NAME
         },
         body
     })

--- a/static/map/map.js
+++ b/static/map/map.js
@@ -13,7 +13,8 @@ import {
     MAP_COUNTY_LAYER_ID,
     MAP_COUNTY_LAYER_URL,
     DEFAULT_ORG_ID,
-    DETROIT_COUNTY_GEOIDS
+    DETROIT_COUNTY_GEOIDS,
+    APOLLO_CLIENT_NAME
 } from '/static/utils/constants.js'
 
 // Document selectors
@@ -197,7 +198,8 @@ function getZones() {
     return fetch(BGA_URL, {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'apollographql-client-name': APOLLO_CLIENT_NAME
         },
         body: getZonesQuery({ filterByOrgId: filterByOrgId })
     })
@@ -216,7 +218,8 @@ function getMultiTestData() {
     return fetch(BGA_URL, {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'apollographql-client-name': APOLLO_CLIENT_NAME
         },
         body: getAggregateMultitestResultsQuery({ filterByOrgAndCounty: filterByOrgAndCounty })
     })

--- a/static/measure/handleResults.js
+++ b/static/measure/handleResults.js
@@ -1,7 +1,7 @@
 'use strict'
 
 import { getUuid } from '/static/utils/cookies.js'
-import { BGA_URL } from '/static/utils/constants.js'
+import { BGA_URL, APOLLO_CLIENT_NAME } from '/static/utils/constants.js'
 import { rollupResults, displayResults } from '/static/utils/resultsUtils.js'
 import { uploadSurveyData } from '/static/measure/survey.js'
 
@@ -62,7 +62,8 @@ async function uploadData(results) {
   return fetch(BGA_URL, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      'apollographql-client-name': APOLLO_CLIENT_NAME
     },
     body: body
   })
@@ -98,7 +99,8 @@ async function uploadNoServiceData(results) {
   return fetch(BGA_URL, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      'apollographql-client-name': APOLLO_CLIENT_NAME
     },
     body: body
   })

--- a/static/measure/survey.js
+++ b/static/measure/survey.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import { BGA_URL } from '/static/utils/constants.js'
+import { BGA_URL, APOLLO_CLIENT_NAME } from '/static/utils/constants.js'
 import { survey } from '/static/utils/constants.js'
 import { getUuid } from '/static/utils/cookies.js'
 
@@ -535,7 +535,8 @@ async function nextQuestion() {
     return fetch(BGA_URL, {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'apollographql-client-name': APOLLO_CLIENT_NAME
         },
         body: body
     })

--- a/static/results/results.js
+++ b/static/results/results.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import { BGA_URL } from '/static/utils/constants.js'
+import { BGA_URL, APOLLO_CLIENT_NAME } from '/static/utils/constants.js'
 import { displayResults }from '/static/utils/resultsUtils.js'
 
 /**
@@ -31,7 +31,8 @@ async function getResults(id) {
     return fetch(BGA_URL, {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'apollographql-client-name': APOLLO_CLIENT_NAME
         },
         body
     })

--- a/static/test/rst/src/testClient.js
+++ b/static/test/rst/src/testClient.js
@@ -1,7 +1,7 @@
 'use strict'
 
 import { LOCAL_TESTING_FLAG } from '/static/utils/constants.js'
-import { BGA_URL } from '/static/utils/constants.js'
+import { BGA_URL, APOLLO_CLIENT_NAME } from '/static/utils/constants.js'
 
 /**
  * Creates a Web Worker to run the ping, upload, and download tests, returning the results
@@ -40,6 +40,7 @@ async function runTest(handleProgress = () => {}, metadata) {
     testWorker.postMessage({
         localFlag: LOCAL_TESTING_FLAG,
         bgaUrl: BGA_URL,
+        apolloClientName: APOLLO_CLIENT_NAME,
         metadata: metadata
     });
 

--- a/static/test/rst/src/testWorker.js
+++ b/static/test/rst/src/testWorker.js
@@ -8,6 +8,7 @@ const url = 'wss://test.ready.net';
 
 let LOCAL_TESTING_FLAG
 let BGA_URL
+let APOLLO_CLIENT_NAME
 
 /**
  * Runs the client-side component of the ping test.
@@ -296,7 +297,8 @@ async function getMetadata() {
     return fetch(BGA_URL, {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'apollographql-client-name': APOLLO_CLIENT_NAME
         },
         body: body
     })
@@ -315,6 +317,7 @@ async function getMetadata() {
 onmessage = async function(e) {
     LOCAL_TESTING_FLAG = e.data.localFlag
     BGA_URL = e.data.bgaUrl
+    APOLLO_CLIENT_NAME = e.data.apolloClientName
 
     let pingResults;
     let uploadResults;

--- a/static/utils/constants.js
+++ b/static/utils/constants.js
@@ -324,3 +324,5 @@ export const MAP_LIGHT_STYLE = "mapbox://styles/mapbox/light-v10"
 export const MAP_COUNTY_LAYER_ID = "bosscounty_mapbox"
 export const MAP_COUNTY_LAYER_URL = "mapbox://readygeo.boss_county"
 export const DETROIT_COUNTY_GEOIDS = ['26163']
+
+export const APOLLO_CLIENT_NAME = 'Community Broadband Kit'

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -29,3 +29,5 @@ const domains = {
 }
 
 exports.DEFAULT_DOMAIN = LOCAL_TESTING_FLAG ? domains.default : domains.default
+
+export const APOLLO_CLIENT_NAME = 'Community Broadband Kit'

--- a/utils/getAssets.js
+++ b/utils/getAssets.js
@@ -1,7 +1,8 @@
 const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
 const {
     BGA_URL,
-    DEFAULT_DOMAIN
+    DEFAULT_DOMAIN,
+    APOLLO_CLIENT_NAME
 } = require('./constants')
 
 /**
@@ -52,7 +53,8 @@ async function getAssets(host = DEFAULT_DOMAIN) {
     return fetch(BGA_URL, {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'apollographql-client-name': APOLLO_CLIENT_NAME
         },
         body
     })

--- a/utils/resultsUtils.js
+++ b/utils/resultsUtils.js
@@ -1,5 +1,5 @@
 const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
-const { BGA_URL } = require('./constants')
+const { BGA_URL, APOLLO_CLIENT_NAME } = require('./constants')
 
 /**
  * Gets the overall service status based on NTIA guidlines
@@ -103,7 +103,8 @@ exports.getResults = async (id) => {
     return fetch(BGA_URL, {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'apollographql-client-name': APOLLO_CLIENT_NAME
         },
         body
     })


### PR DESCRIPTION
## Description

This PR adds a [`name`](https://www.apollographql.com/docs/react/api/core/ApolloClient#apolloclientoptions-name) to the apollo requests to have it add headers for client awareness in our metrics setup.